### PR TITLE
Remove unnecessary $ symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To build it, you must first install [Rust](https://www.rust-lang.org/tools/insta
 Then install `mdbook` using cargo:
 
 ```bash
-$ cargo install mdbook
+cargo install mdbook
 ```
 
 and build the book from this directory:

--- a/src/actor-model/actors-in-blockchain.md
+++ b/src/actor-model/actors-in-blockchain.md
@@ -64,14 +64,14 @@ contract binary. The `cw4-group` contract from
 now, so we will start with compiling it. Start with cloning the repository:
 
 ```bash
-$ git clone git@github.com:CosmWasm/cw-plus.git
+git clone git@github.com:CosmWasm/cw-plus.git
 ```
 
 Then go to `cw4-group` contract and build it:
 
 ```bash
-$ cd cw-plus/contracts/cw4-group
-$ docker run --rm -v "$(pwd)":/code \
+cd cw-plus/contracts/cw4-group
+docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/workspace-optimizer:0.12.6
@@ -86,7 +86,7 @@ When the contract binary is built, the first interaction with CosmWasm is upload
 it to the blockchain (assuming you have your wasm binary in the working directory):
 
 ```bash
-$ wasmd tx wasm store ./cw4-group.wasm --from wallet $TXFLAG -y -b block
+wasmd tx wasm store ./cw4-group.wasm --from wallet $TXFLAG -y -b block
 ```
 
 As a result of such an operation you would get json output like this:
@@ -109,7 +109,7 @@ stored contract - in my case the contract code was stored in blockchain under
 the id of `1069`. I can now look at the code by querying for it:
 
 ```bash
-$ wasmd query wasm code 1069 code.wasm
+wasmd query wasm code 1069 code.wasm
 ```
 
 And now the important thing - the contract code is not an actor. So, what is a
@@ -127,15 +127,15 @@ instantiation is calling a constructor. To do that, I would send an
 instantiate message to my contract:
 
 ```bash
-$ wasmd tx wasm instantiate 1069 '{"members": []}' --from wallet --label "Group 1" --no-admin $TXFLAG -y
+wasmd tx wasm instantiate 1069 '{"members": []}' --from wallet --label "Group 1" --no-admin $TXFLAG -y
 ```
 
 What I do here is create a new contract and immediately call the `Instantiate`
 message on it. The structure of such a message is different for every contract
 code. In particular, the `cw4-group` Instantiate message contains two fields:
 
-* `members` field which is the list of initial group members optional `admin`
-* field which defines an address of who can add or remove
+- `members` field which is the list of initial group members optional `admin`
+- field which defines an address of who can add or remove
   a group member
 
 In this case, I created an empty group with no admin - so which could never
@@ -184,7 +184,7 @@ got one when you added the key to `wasmd`:
 
 ```bash
 # add wallets for testing
-$ wasmd keys add wallet3
+wasmd keys add wallet3
 - name: wallet3
   type: local
   address: wasm1dk6sq0786m6ayg9kd0ylgugykxe0n6h0ts7d8t
@@ -195,7 +195,7 @@ $ wasmd keys add wallet3
 You can always check your address:
 
 ```bash
-$ wasmd keys show wallet
+wasmd keys show wallet
 - name: wallet
   type: local
   address: wasm1um59mldkdj8ayl5gknp9pnrdlw33v40sh5l4nx
@@ -214,7 +214,7 @@ So, we have our contract, let's try to do something with it - query would be the
 easiest thing to do. Let's do it:
 
 ```bash
-$ wasmd query wasm contract-state smart wasm1u0grxl65reu6spujnf20ngcpz3jvjfsp5rs7lkavud3rhppnyhmqqnkcx6 '{ "list_members": {} }'
+wasmd query wasm contract-state smart wasm1u0grxl65reu6spujnf20ngcpz3jvjfsp5rs7lkavud3rhppnyhmqqnkcx6 '{ "list_members": {} }'
 data:
   members: []
 ```
@@ -247,13 +247,13 @@ So, let's make a new group contract, but this time we would
 make ourselves an admin. First, check our wallet address:
 
 ```bash
-$ wasmd keys show wallet
+wasmd keys show wallet
 ```
 
 And instantiate a new group contract - this time with proper admin:
 
 ```bash
-$ wasmd tx wasm instantiate 1069 '{"members": [], "admin": "wasm1um59mldkdj8ayl5gknp9pnrdlw33v40sh5l4nx"}' --from wallet --label "Group 1" --no-admin $TXFLAG -y
+wasmd tx wasm instantiate 1069 '{"members": [], "admin": "wasm1um59mldkdj8ayl5gknp9pnrdlw33v40sh5l4nx"}' --from wallet --label "Group 1" --no-admin $TXFLAG -y
 ..
 logs:
 - events:
@@ -278,7 +278,7 @@ the contract.
 Now let's query our new contract for the member's list:
 
 ```bash
-$ wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "list_members": {} }'
+wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "list_members": {} }'
 data:
   members: []
 ```
@@ -286,7 +286,7 @@ data:
 Just like before - no members initially. Now check an admin:
 
 ```
-$ wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "admin": {} }'
+wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "admin": {} }'
 data:
   admin: wasm1um59mldkdj8ayl5gknp9pnrdlw33v40sh5l4nx
 ```
@@ -309,7 +309,7 @@ us, it would always be 1.
 Let's query the contract again to check if our message changed anything:
 
 ```bash
-$ wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "list_members": {} }'
+wasmd query wasm contract-state smart wasm1n5x8hmstlzdzy5jxd70273tuptr4zsclrwx0nsqv7qns5gm4vraqeam24u '{ "list_members": {} }'
 data:
   members:
   - addr: wasm1um59mldkdj8ayl5gknp9pnrdlw33v40sh5l4nx

--- a/src/basics/building-contract.md
+++ b/src/basics/building-contract.md
@@ -9,7 +9,7 @@ However, we need to create a wasm binary to upload the contract to blockchain.
 We can do it by passing an additional argument to the build command:
 
 ```
-$ cargo build --target wasm32-unknown-unknown --release --lib
+cargo build --target wasm32-unknown-unknown --release --lib
 ```
 
 The `--target` argument tells cargo to perform cross-compilation for a given target instead of
@@ -51,9 +51,9 @@ When the contract is built, the last step is to ensure it is a valid CosmWasm co
 `cosmwasm-check` on it:
 
 ```
-$ cargo wasm
+cargo wasm
 ...
-$ cosmwasm-check target/wasm32-unknown-unknown/release/contract.wasm
+cosmwasm-check target/wasm32-unknown-unknown/release/contract.wasm
 Available capabilities: {"cosmwasm_1_1", "iterator", "staking", "stargate"}
 
 target/wasm32-unknown-unknown/release/contract.wasm: pass

--- a/src/basics/create-project.md
+++ b/src/basics/create-project.md
@@ -3,7 +3,7 @@
 As smart contracts are Rust library crates, we will start with creating one:
 
 ```
-$ cargo new --lib ./contract
+cargo new --lib ./contract
 ```
 
 You created a simple Rust library, but it is not yet ready to be a smart contract. The first thing

--- a/src/setting-up-env.md
+++ b/src/setting-up-env.md
@@ -23,9 +23,9 @@ To install `wasmd`, first install the [golang](https://github.com/golang/go/wiki
 clone the `wasmd` and install it:
 
 ```
-$ git clone git@github.com:CosmWasm/wasmd.git
-$ cd ./wasmd
-$ make install
+git clone git@github.com:CosmWasm/wasmd.git
+cd ./wasmd
+make install
 ```
 
 Also, to be able to upload Rust Wasm Contracts into the blockchain, you will need
@@ -40,13 +40,13 @@ utility. It allows you to check if the wasm binary is a proper smart contract
 ready to upload into the blockchain. You can install it using cargo:
 
 ```
-$ cargo install cosmwasm-check
+cargo install cosmwasm-check
 ```
 
 If the installation succeeds, you should be able to execute the utility from your command line.
 
 ```
-$ cosmwasm-check --version
+cosmwasm-check --version
 Contract checking 1.1.6
 ```
 
@@ -57,12 +57,12 @@ Checkout the [sylvia](https://github.com/CosmWasm/sylvia) repository and run the
 its folder:
 
 ```
-$ git clone git@github.com:CosmWasm/sylvia.git
-$ cd ./sylvia
+git clone git@github.com:CosmWasm/sylvia.git
+cd ./sylvia
 sylvia $ cargo test
 ```
 
-You should see that everything in the repository gets compiled, and all tests pass. 
+You should see that everything in the repository gets compiled, and all tests pass.
 
 `sylvia` framework contains some examples of contracts. To find them go to `contracts` directory.
 These contracts are maintained by CosmWasm creators, so contracts in there should follow good practices.

--- a/src/wasmd-quick-start/preparing-account.md
+++ b/src/wasmd-quick-start/preparing-account.md
@@ -1,9 +1,9 @@
 # Preparing account
 
-The first thing you need to interact with testnet is a valid account. Start with adding a new key to the `wasmd` configuration: 
+The first thing you need to interact with testnet is a valid account. Start with adding a new key to the `wasmd` configuration:
 
 ```
-$ wasmd keys add wallet
+wasmd keys add wallet
 - name: wallet
   type: local
   address: wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux
@@ -13,9 +13,10 @@ $ wasmd keys add wallet
 ```
 
 As a result of this command, you get information about just the prepared account. Two things are relevant here:
-* address is your identity in the blockchain
-* mnemonic (omitted by myself in the example) is 12 words that allow you to recreate an account so you can use it, for
-example, from a different machine
+
+- address is your identity in the blockchain
+- mnemonic (omitted by myself in the example) is 12 words that allow you to recreate an account so you can use it, for
+  example, from a different machine
 
 For testing purposes, storing the mnemonic is probably never necessary, but it is critical information to keep safe in the real world.
 
@@ -24,7 +25,7 @@ blockchain - we call this the "gas cost" of an operation. Usually, you would nee
 you can typically create as many tokens as you want on your accounts. To do so on malaga network, invoke:
 
 ```
-$ curl -X POST --header "Content-Type: application/json" \
+curl -X POST --header "Content-Type: application/json" \
   --data '{ "denom": "umlg", "address": "wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux" }' \
   https://faucet.malaga-420.cosmwasm.com/credit
 ```
@@ -36,7 +37,7 @@ tokens used to pay gas fees in the malaga testnet.
 You can now verify your account tokens balance by invoking (substituting my address with yours):
 
 ```
-$ wasmd query bank balances wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux
+wasmd query bank balances wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux
 balances:
 - amount: "100000000"
   denom: umlg

--- a/src/wasmd-quick-start/testnet-interaction.md
+++ b/src/wasmd-quick-start/testnet-interaction.md
@@ -7,13 +7,13 @@ use an example `cw4-group` from the `cw-plus` repository. Start with cloning
 it:
 
 ```
-$ git clone git@github.com:CosmWasm/cw-plus.git
+git clone git@github.com:CosmWasm/cw-plus.git
 ```
 
 Now go to cloned repo and run Rust optimizer on it:
 
 ```
-$ docker run --rm -v "$(pwd)":/code \
+docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/workspace-optimizer:0.12.6
@@ -25,7 +25,7 @@ have an `artifact` directory in your repo, and there should be a
 note that `wallet` is name of the key you created in the previous chapter:
 
 ```
-$ wasmd tx wasm store ./artifacts/cw4_group.wasm --from wallet $TXFLAG -y -b block
+wasmd tx wasm store ./artifacts/cw4_group.wasm --from wallet $TXFLAG -y -b block
 
 ...
 logs:
@@ -55,7 +55,7 @@ Now, when we have our code uploaded, we can go forward and instantiate a
 contract to create its new instance:
 
 ```
-$ wasmd tx wasm instantiate 12 \
+wasmd tx wasm instantiate 12 \
   '{ "admin": "wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux", "members": [] }' \
   --from wallet --label "Group" --no-admin $TXFLAG -y
 
@@ -111,7 +111,7 @@ example.
 Now let's go forward with querying our contract:
 
 ```
-$ wasmd query wasm contract-state smart \
+wasmd query wasm contract-state smart \
   wasm18yn206ypuxay79gjqv6msvd9t2y49w4fz8q7fyenx5aggj0ua37q3h7kwz \
   '{ "list_members": {} }'
 
@@ -127,7 +127,7 @@ single field - empty members list. That was easy, now let's try the last thing:
 the execution:
 
 ```
-$ wasmd tx wasm execute \
+wasmd tx wasm execute \
   wasm18yn206ypuxay79gjqv6msvd9t2y49w4fz8q7fyenx5aggj0ua37q3h7kwz \
   '{ "update_members": { "add": [{ "addr": "wasm1wukxp2kldxae36rgjz28umqtq792twtxdfe6ux", "weight": 1 }], "remove": [] } }' \
   --from wallet $TXFLAG
@@ -142,7 +142,7 @@ happened. But to ensure that there is an effect on blockchain, the best way
 would be to query it once again:
 
 ```
-$ wasmd query wasm contract-state smart \
+wasmd query wasm contract-state smart \
   wasm18yn206ypuxay79gjqv6msvd9t2y49w4fz8q7fyenx5aggj0ua37q3h7kwz \
   '{ "list_members": {} }'
 

--- a/src/wasmd-quick-start/testnet.md
+++ b/src/wasmd-quick-start/testnet.md
@@ -53,6 +53,7 @@ set -x TXFLAG --node $RPC --chain-id $CHAIN_ID --gas-prices 0.05umlg --gas-adjus
 ```
 
 Now source the file to our environment (for fish use `malaga.fish` in place of `malaga.env`):
+
 ```sh
-$ source ./malaga.env
+source ./malaga.env
 ```


### PR DESCRIPTION
"$" Symbol at the start of each copyable line makes the user experience harder. 
- Removed only the necessary lines, the ones contained inside the command are not removed.